### PR TITLE
Move fixtures to conftest.py

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def image1():
+    """Create image1 and automatically close after test."""
+    path = Path("test") / "images" / "acolchado.jpg"
+    with Image.open(path) as image:
+        yield image
+
+
+@pytest.fixture
+def image2():
+    """Create image2 and automatically close after test."""
+    path = Path("test") / "images" / "sheet.jpg"
+    with Image.open(path) as image:
+        yield image
+
+
+@pytest.fixture
+def xord_image():
+    """Create xord_image and automatically close after test."""
+    path = Path("test") / "images" / "xord_image.jpg"
+    with Image.open(path) as image:
+        yield image

--- a/test/test_click_commands.py
+++ b/test/test_click_commands.py
@@ -1,27 +1,17 @@
-from pathlib import Path
 from test.utils import equal_images
 
-import pytest
 from click.testing import CliRunner
 from PIL import Image
 
 from benevolent.cli import xor_code
 
 
-@pytest.fixture
-def xord_image():
-    """Create xord_image and automatically close after test."""
-    path = Path("test") / "images" / "xord_image.jpg"
-    with Image.open(path) as image:
-        yield image
-
-
 def test_xor_image_is_created(tmp_path, xord_image):
     """Test that the correct XOR image is created when running the xor-code command."""
-    path = Path(tmp_path) / "xor_result.jpg"
+    path = tmp_path / "xor_result.jpg"
     CliRunner().invoke(xor_code, ["test/images/acolchado.jpg",
                                   "test/images/sheet.jpg",
-                                  str(path.absolute())])
+                                  str(path.resolve())])
 
     with Image.open(path) as result:
         assert equal_images(xord_image, result)

--- a/test/test_xor_encoder.py
+++ b/test/test_xor_encoder.py
@@ -1,26 +1,6 @@
-from pathlib import Path
 from test.utils import equal_images
 
-import pytest
-from PIL import Image
-
 from benevolent.xor_enconder import create_xor_code
-
-
-@pytest.fixture
-def image1():
-    """Create image1 and automatically close after test."""
-    path = Path("test") / "images" / "acolchado.jpg"
-    with Image.open(path) as image:
-        yield image
-
-
-@pytest.fixture
-def image2():
-    """Create image2 and automatically close after test."""
-    path = Path("test") / "images" / "sheet.jpg"
-    with Image.open(path) as image:
-        yield image
 
 
 def test_same_xor_both_ways(image1, image2):


### PR DESCRIPTION
Test fixtures defined in conftest.py are accessible to all tests in the directory.
This makes it easy to use a certain fixture for any test file.